### PR TITLE
Route normalization improvements and refines the OpenAPI handler response formatting for JSON

### DIFF
--- a/packages/azure-functions-openapi/handlers/openAPI.ts
+++ b/packages/azure-functions-openapi/handlers/openAPI.ts
@@ -50,8 +50,9 @@ export function registerOpenAPIHandler(
             return {
                 status: 200,
                 headers: { 'Content-Type': format === 'json' ? 'application/json' : 'application/x-yaml' },
-                body: (format === 'yaml') ? yamlStringify(openAPIDefinition) : undefined,
-                jsonBody: (format === 'json') ? openAPIDefinition : undefined,
+                body: (format === 'yaml') 
+                    ? yamlStringify(openAPIDefinition) 
+                    : JSON.stringify(openAPIDefinition, null, 2),
             };
         },
         route: finalRoute

--- a/packages/azure-functions-openapi/package.json
+++ b/packages/azure-functions-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apvee/azure-functions-openapi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/apvee/azure-functions-nodejs-monorepo.git"


### PR DESCRIPTION
This pull request improves the route normalization logic for Azure Functions and OpenAPI documentation, ensuring consistent and correct path handling across the codebase. It introduces dedicated normalization functions, updates how routes are registered, and refines the OpenAPI handler response formatting.

**Route normalization improvements:**

* Added `normalizeOpenAPIPath` and `normalizeAzureFunctionRoute` helper functions to standardize route formatting for OpenAPI documentation and Azure Functions registration, respectively. These ensure consistent handling of slashes and route prefixes.
* Updated the `registerPath` function to use the new normalization helpers when registering both Azure Functions and OpenAPI paths, preventing issues with duplicate or missing slashes.

**OpenAPI handler update:**

* Modified the OpenAPI handler to always return a formatted JSON string in the response body for JSON requests, improving readability and consistency.

**Version bump:**

* Incremented the package version from `1.0.1` to `1.0.2` in `package.json` to reflect the new changes.

Resolved the issues #7 and #8 