### PR TITLE
Copilot/dev 2x review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3945,7 +3945,7 @@
     },
     "packages/azure-functions-openapi": {
       "name": "@apvee/azure-functions-openapi",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.1.0",

--- a/packages/azure-functions-openapi/CHANGELOG.md
+++ b/packages/azure-functions-openapi/CHANGELOG.md
@@ -4,16 +4,23 @@ All notable changes to `@apvee/azure-functions-openapi` are documented in this
 file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 2.0.0 hardening
+## [2.0.0]
 
 ### Added
 
+- Complete v2 rewrite around Azure Functions v4 module augmentation:
+  `app.openAPISetup`, `app.openAPIPath`, `app.openAPIWebhook`,
+  `app.openAPISchema`, and dedicated security helpers now replace the v1
+  registration functions.
 - Dedicated side-effect entrypoint `@apvee/azure-functions-openapi/register` for
   consumers that want an explicit augmentation import.
 - Pluggable internal logger (`setLogger` / `resetLogger`) so that the library
   no longer hard-codes `console.warn` for configuration warnings.
 - `exports` map and `engines.node` field on the published package.
 - ESM/CJS-safe re-exports of route helpers via `internal/route.ts`.
+- Secure host resolution controls: `OpenAPISetupConfig.trustHostHeader`
+  defaults to `false`, while `trustedHosts` can be used as an allowlist when
+  request-derived server URLs are explicitly enabled.
 - Unit-test suite (Vitest) covering JSON content-type detection, the safe
   request proxy, route normalization, transform/response warnings, and the
   Azure Function Key OpenAPI mapping.
@@ -22,9 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default `authLevel` configured by `app.openAPISetup({ authLevel })` is now
   applied to subsequent `openAPIPath` / `openAPIWebhook` registrations that
   omit the option explicitly.
+- OpenAPI documents can be generated as OpenAPI 3.1.0, OpenAPI 3.0.3, and
+  Swagger 2.0, with JSON and YAML output formats.
+- Native Azure security helpers for Function Keys, EasyAuth, Microsoft Entra ID
+  bearer tokens, client credentials, and custom API keys.
 
 ### Changed
 
+- The default generated OpenAPI version is now only `3.1.0`; `3.0.3` and `2.0`
+  remain available when explicitly requested via `versions`.
 - `parseBody` now accepts every JSON media type allowed by RFC 6839, i.e. any
   `application/json` and any `*+json` structured-syntax suffix
   (`application/problem+json`, `application/ld+json`, etc.).
@@ -32,23 +45,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserving prototype methods (`request.headers.get(...)`) and non-enumerable
   properties that were previously lost by the old `Object.assign`-based
   implementation.
-- Swagger UI assets are now read asynchronously and **cached in memory**;
+- Swagger UI assets are now read asynchronously and cached in memory;
   conditional `If-None-Match` requests are answered with `304 Not Modified`.
-- Azure Function Keys are documented as **two** OpenAPI security schemes
-  (header `x-functions-key` _and_ query `code`) when both locations are
-  allowed, so generated documents reflect what the Azure runtime accepts.
+- Swagger UI asset resolution now uses `require.resolve('swagger-ui-dist/...')`
+  so package resolution works under pnpm, Yarn PnP, monorepos, and
+  `WEBSITE_RUN_FROM_PACKAGE`.
+- Generated OpenAPI documents are memoised per `(version, format, servers)` to
+  avoid re-serialising unchanged specs on every request.
+- Azure Function Keys are documented as two OpenAPI security schemes (header
+  `x-functions-key` and query `code`) when both locations are allowed, so
+  generated documents reflect what the Azure runtime accepts.
 - TypeScript build target raised to `ES2022` for both packages.
+- Runtime compatibility is Node.js `>=18`, `@azure/functions` `^4.5.2`, and
+  `zod` `^4.0.0`.
+- `yaml` was upgraded to `^2.8.3`, and `openapi3-ts` is now a direct runtime
+  dependency.
 - ESLint + Prettier + EditorConfig added at the repo root.
 
 ### Fixed
 
+- Swagger UI script interpolation now escapes `</`, `&`, `<`, `>`, U+2028, and
+  U+2029 before embedding generated data.
+- URLs logged by the built-in handlers redact sensitive query parameters:
+  `code`, `x-functions-key`, `access_token`, `token`, `api_key`, and `apiKey`.
+- `parseEasyAuthPrincipal` rejects non-string values and enforces a 64 KiB
+  upper bound on base64 input.
+- Startup now warns when OpenAPI endpoints use `authLevel: 'anonymous'` while
+  running on Azure (`WEBSITE_SITE_NAME` is present).
 - README examples and migration sections no longer claim that all three
-  OpenAPI versions are emitted by default — only `3.1.0` is, and additional
+  OpenAPI versions are emitted by default; only `3.1.0` is, and additional
   versions remain opt-in via `versions`.
 - Internal JSDoc no longer references the obsolete `app.openapi()` factory.
 
 ### Removed
 
+- v1 registration APIs such as `registerOpenAPIHandler`,
+  `registerSwaggerUIHandler`, `registerFunction`, `registerApiKeySecuritySchema`,
+  and `registerTypeSchema`; use the `app.openAPI*` methods instead.
 - The unused `SAFE_REQUEST_PROTOTYPE` static prototype previously held by
   `internal/parsing.ts`.
 

--- a/packages/azure-functions-openapi/README.md
+++ b/packages/azure-functions-openapi/README.md
@@ -41,7 +41,7 @@ app.openAPIPath("GetUser", "Get user by ID", {
 ### Key Capabilities
 
 - 🎯 **Automatic Type Inference** - TypeScript infers all parameter types from your Zod schemas
-- 📝 **Multi-Version OpenAPI** - Generate specs in OpenAPI 2.0, 3.0.3, and 3.1.0 formats
+- 📝 **Multi-Version OpenAPI** - OpenAPI 3.1.0 by default, with opt-in OpenAPI 3.0.3 and Swagger 2.0 output
 - 🎨 **Integrated Swagger UI** - Beautiful, interactive API documentation out of the box
 - 🔒 **Azure Security Built-in** - Native support for Function Keys, EasyAuth, and Azure AD
 - ✅ **Runtime Validation** - Automatic request/response validation with detailed error messages
@@ -120,6 +120,7 @@ v2.0 introduces native support for multiple Azure authentication methods:
 - **Azure AD Bearer Token** - Manual JWT validation for Microsoft Entra ID
 - **Azure AD Client Credentials** - Service-to-service authentication with app roles
 - **Custom API Keys** - Flexible header/query/cookie-based authentication
+- **Safe host resolution** - `servers` is never derived from the request `Host` header unless you explicitly opt in with `trustHostHeader`
 
 ```typescript
 // Azure EasyAuth example
@@ -152,7 +153,7 @@ Fully aligned with **Zod 4.x**, ensuring compatibility with the latest validatio
 ```json
 {
   "peerDependencies": {
-    "@azure/functions": "^4.0.0",
+    "@azure/functions": "^4.5.2",
     "zod": "^4.0.0"
   }
 }
@@ -179,12 +180,15 @@ app.openAPIWebhook('OrderCreated', 'Notify when order is created', {
 Setup is now **much simpler** with a single `openAPISetup()` call:
 
 ```typescript
-// Generate the OpenAPI documents you want — only OpenAPI 3.1.0 / JSON+YAML are emitted by default
+// Only OpenAPI 3.1.0 in JSON/YAML is emitted by default.
+// Add 3.0.3 or 2.0 only when your tooling needs them.
 app.openAPISetup({
   info: { title: 'My API', version: '1.0.0' },
   routePrefix: 'api',
   versions: ['3.1.0', '3.0.3', '2.0'], // Optional, defaults to ['3.1.0']
   formats: ['json', 'yaml'],           // Optional, defaults to ['json', 'yaml']
+  servers: [{ url: 'https://api.example.com' }],
+  trustHostHeader: false,               // Optional, defaults to false
   swaggerUI: { 
     enabled: true,                     // Optional, defaults to true
     route: 'docs'                      // Optional, defaults to 'swagger-ui'
@@ -329,13 +333,13 @@ app.openAPIPath('UpdateTodo', 'Update a todo item', {
 
 ### Multi-Version OpenAPI Support
 
-Generate OpenAPI specifications in multiple versions and formats simultaneously:
+Generate OpenAPI specifications in multiple versions and formats when your tooling needs them. By default, the library emits OpenAPI 3.1.0 in JSON and YAML only.
 
 - **OpenAPI 3.1.0** - Latest spec with full JSON Schema support and webhooks
 - **OpenAPI 3.0.3** - Widely supported by most tools
 - **OpenAPI 2.0 (Swagger)** - Legacy support for older tools
 
-Export in **JSON** or **YAML** format to suit your needs.
+Add `versions: ["3.1.0", "3.0.3", "2.0"]` to generate all supported versions simultaneously. Export in **JSON** or **YAML** format to suit your needs.
 
 ### Integrated Swagger UI
 
@@ -509,7 +513,7 @@ npm install @azure/functions zod
 | Package                          | Version    | Notes                    |
 | -------------------------------- | ---------- | ------------------------ |
 | `@apvee/azure-functions-openapi` | `^2.0.0`   | This library             |
-| `@azure/functions`               | `^4.0.0`   | Azure Functions runtime  |
+| `@azure/functions`               | `^4.5.2`   | Azure Functions runtime  |
 | `zod`                            | `^4.0.0`   | Schema validation        |
 | Node.js                          | `>=18.0.0` | Recommended: Node 20 LTS |
 
@@ -751,6 +755,8 @@ app.openAPISetup({
   },
 
   // Optional: Server configurations
+  // Recommended in production. When omitted, `servers` is not derived from
+  // the request Host header unless `trustHostHeader` is explicitly enabled.
   servers: [
     {
       url: "https://api.example.com",
@@ -805,6 +811,13 @@ app.openAPISetup({
   // Optional: Output formats (default: ['json', 'yaml'])
   formats: ["json", "yaml"],
 
+  // Optional: trust the incoming Host header for generated `servers`
+  // (default: false). Prefer explicit `servers` in production.
+  trustHostHeader: false,
+
+  // Optional: host allowlist used only when `trustHostHeader: true`
+  trustedHosts: ["api.example.com", "staging-api.example.com"],
+
   // Optional: Swagger UI configuration
   swaggerUI: {
     enabled: true, // default: true
@@ -827,13 +840,15 @@ app.openAPISetup({
 | `authLevel`           | `'anonymous' \| 'function' \| 'admin'` | `'anonymous'`            | Auth level for OpenAPI/Swagger endpoints         |
 | `versions`            | `Array<'2.0' \| '3.0.3' \| '3.1.0'>`   | `['3.1.0']`              | OpenAPI versions to generate                     |
 | `formats`             | `Array<'json' \| 'yaml'>`              | `['json', 'yaml']`       | Output formats                                   |
+| `trustHostHeader`     | `boolean`                              | `false`                  | Derive `servers` from the request `Host` header only when explicitly enabled |
+| `trustedHosts`        | `string[]`                             | `[]`                     | Hostname allowlist used when `trustHostHeader` is enabled |
 | `swaggerUI.enabled`   | `boolean`                              | `true`                   | Enable/disable Swagger UI                        |
 | `swaggerUI.route`     | `string`                               | `'swagger-ui'`           | Swagger UI route                                 |
 | `swaggerUI.authLevel` | `'anonymous' \| 'function' \| 'admin'` | Same as main `authLevel` | Auth level for Swagger UI                        |
 
 #### Generated Endpoints
 
-Based on your configuration, the following endpoints are automatically created:
+Based on your configuration, the following endpoints are automatically created. With the default `versions: ["3.1.0"]`, only the 3.1.0 document routes are registered; 3.0.3 and 2.0 routes are registered only when you add those versions.
 
 **OpenAPI Documents:**
 
@@ -7577,7 +7592,7 @@ Update your `package.json`:
 {
   "dependencies": {
     "@apvee/azure-functions-openapi": "^2.0.0",
-    "@azure/functions": "^4.0.0",
+    "@azure/functions": "^4.5.2",
     "zod": "^4.0.0"
   }
 }
@@ -8221,7 +8236,7 @@ See the [LICENSE](LICENSE) file for full details.
 #### 📦 Package
 
 - **npm Package**: [@apvee/azure-functions-openapi](https://www.npmjs.com/package/@apvee/azure-functions-openapi)
-- **Version**: 2.0.0-alpha.0
+- **Version**: 2.0.0
 - **Install**: `npm install @apvee/azure-functions-openapi`
 
 #### 🔗 Repository

--- a/packages/azure-functions-openapi/package.json
+++ b/packages/azure-functions-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apvee/azure-functions-openapi",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/apvee/azure-functions-nodejs-monorepo.git",


### PR DESCRIPTION
This pull request finalizes the 2.0.0 release of `@apvee/azure-functions-openapi`, completing the v2 rewrite and updating both the package and documentation to reflect new features, improved security, and breaking changes. The most important changes are grouped below.

**Major v2.0.0 Release and Core Features**

* The package is now at version `2.0.0`, marking the completion of a full rewrite around Azure Functions v4 module augmentation. New APIs (`app.openAPISetup`, `app.openAPIPath`, `app.openAPIWebhook`, `app.openAPISchema`) replace the older v1 registration functions. [[1]](diffhunk://#diff-ed19efc903b7f0b0bc4b3415e332bc5a63250fa69fa1492e9628a8bf0aec7e65L3-R3) [[2]](diffhunk://#diff-04471d5785d7e41b47a0c87461a22ae25995f607be3197a3540e7b90e4ab5b78L7-R23)
* Native Azure security helpers are introduced for Function Keys, EasyAuth, Microsoft Entra ID bearer tokens, client credentials, and custom API keys. [[1]](diffhunk://#diff-04471d5785d7e41b47a0c87461a22ae25995f607be3197a3540e7b90e4ab5b78R32-R84) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998R123)
* The library now supports generating OpenAPI docs in 3.1.0 (default), 3.0.3, and Swagger 2.0, with both JSON and YAML output formats. [[1]](diffhunk://#diff-04471d5785d7e41b47a0c87461a22ae25995f607be3197a3540e7b90e4ab5b78R32-R84) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L44-R44) [[3]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L332-R342)

**Security and Host Resolution Improvements**

* Host resolution is now secure by default: `OpenAPISetupConfig.trustHostHeader` defaults to `false`, and a `trustedHosts` allowlist is available for explicit opt-in. The README and changelog document this behavior and recommend explicit `servers` configuration in production. [[1]](diffhunk://#diff-04471d5785d7e41b47a0c87461a22ae25995f607be3197a3540e7b90e4ab5b78L7-R23) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L182-R191) [[3]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998R758-R759) [[4]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998R814-R820) [[5]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998R843-R851)

**Documentation and Compatibility Updates**

* The README and changelog are updated throughout to clarify default behaviors, new configuration options, and breaking changes. Examples now show that only OpenAPI 3.1.0 is emitted by default, and additional versions/formats are opt-in. [[1]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L182-R191) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L332-R342) [[3]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998R843-R851)
* Minimum required versions for dependencies are updated: `@azure/functions` is now `^4.5.2` and Node.js is `>=18`. [[1]](diffhunk://#diff-04471d5785d7e41b47a0c87461a22ae25995f607be3197a3540e7b90e4ab5b78R32-R84) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L155-R156) [[3]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L512-R516) [[4]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L7580-R7595)
* The package version is set to `2.0.0` (was previously `2.0.0-alpha.1`), and the README now reflects the stable release. [[1]](diffhunk://#diff-ed19efc903b7f0b0bc4b3415e332bc5a63250fa69fa1492e9628a8bf0aec7e65L3-R3) [[2]](diffhunk://#diff-e05323b722a1ff4546aa5b9226b0c33d3be97beb4c428f15810b8b4f8a22e998L8224-R8239)

**Removed/Deprecated APIs**

* All v1 registration APIs are removed. Consumers must migrate to the new `app.openAPI*` methods.

These changes solidify the library's API, enhance security, and clarify usage for consumers upgrading to v2.